### PR TITLE
Added vars file for Rocky Linux.

### DIFF
--- a/vars/Rocky.yml
+++ b/vars/Rocky.yml
@@ -1,0 +1,9 @@
+---
+# RedHat vars file for deploy_aide
+
+daid_package_name: aide
+daid_conf_path: /etc
+daid_conf_name: aide.conf
+daid_db_path: /var/lib/aide
+daid_db_name: aide.db.gz
+daid_new_db_name: aide.db.new.gz


### PR DESCRIPTION
I was seeing the error fatal: [instance]: FAILED! => {"msg": "No file was found when using first_found."}, when running against Rocky Linux 8 & 9, even though a vars/Redhat.yml file exists and was being used when running molecule tests locally.